### PR TITLE
Write bindgen bindings to OUT_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ description = "FFI bindings for c-blosc2"
 
 [features]
 # run bindgen when building, requires llvm
-bindgen = []
+bindgen = ["dep:bindgen"]
 zstd = []
 
 [dependencies]
 cc = "1.0"
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = { version = "0.65.1", optional = true }
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ bindgen = ["dep:bindgen"]
 zstd = []
 
 [dependencies]
-cc = "1.0"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -87,8 +87,9 @@ fn bindgen_rs() {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
-        .write_to_file("src/bindings.rs")
+        .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 
 use std::{ffi::c_void, ptr::null_mut};
 
+#[cfg(not(feature = "bindgen"))]
 include!("bindings.rs");
+#[cfg(feature = "bindgen")]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// Defaults mirror BLOSC2_CPARAMS_DEFAULTS in blosc2.h
 ///


### PR DESCRIPTION
It is customary to leave the source tree unchanged and instead use `OUT_DIR` for build artifacts

This also skips building `bindgen` if not requested